### PR TITLE
Allow the angular-time-picker package in bower to expose css 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
 	}],
 	"main": [
 		"dist/angular-time-picker.js",
-		"dist/angular-time-picker.tpl.js"
+		"dist/angular-time-picker.css"
 	],
 	"ignore": [
 		"node_modules",


### PR DESCRIPTION
This allows tools like [wiredep](https://github.com/taptapship/wiredep), [grunt-bower-concat](2) and [main-bower-files](3) to import angular-time-picker CSS from the bower_components directory.
