### PR TITLE
Add main field in package.json & expose CSS via style field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"description": "Angular Time Picker - AngularJS directive for time picker",
 	"version": "1.0.0",
 	"main":"dist/angular-time-picker.js",
+	"style":"dist/angular-time-picker.css",
 	"repository": {
 		"type": "git",
 		"url": "git@github.com:wingify/angular-time-picker.git"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "angular-time-picker",
 	"description": "Angular Time Picker - AngularJS directive for time picker",
 	"version": "1.0.0",
+	"main":"dist/angular-time-picker.js",
 	"repository": {
 		"type": "git",
 		"url": "git@github.com:wingify/angular-time-picker.git"


### PR DESCRIPTION
As stated in NPM documentation of [`main field`](https://docs.npmjs.com/files/package.json#main)

> The main field is a module ID that is the primary entry point to your program. That is, if your package is named foo, and a user installs it, and then does require("foo"), then your main module's exports object will be returned.

This would work well when adding browserify support

Also many modules are starting to expose their css entry files in their package.json files via the `style` field . This allows tools like [`npm-css`](https://github.com/defunctzombie/npm-css), [`rework-npm`](https://github.com/reworkcss/rework-npm), and [`npm-less`](https://github.com/Raynos/npm-less) to import angular-time-picker CSS from the node_modules directory. Also this plays well with browserify plugins (like [`parcelify`](https://github.com/rotundasoftware/parcelify)) which helps in bundling CSS together from npm packages
