### PR TITLE
Add support for jit-grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,12 +62,5 @@ module.exports = function (grunt) {
     grunt.registerTask('build', [ 'clean:before', 'html2js', 'jshint', 'copy:src', 'minify' ]);
     grunt.registerTask('unit', [ 'html2js', 'karma:unit' ]);
 
-    grunt.loadNpmTasks('grunt-html2js');
-    grunt.loadNpmTasks('grunt-karma');
-    grunt.loadNpmTasks('grunt-serve');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-contrib-cssmin');
-    grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-copy');
+    require('jit-grunt')(grunt);
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"grunt-contrib-uglify": "^0.9.2",
 		"grunt-contrib-copy": "~0.4.1",
 		"grunt-contrib-clean": "~0.5.0",
+		"jit-grunt": "^0.9.1",
 		"karma": "^0.12.25",
 		"karma-chrome-launcher": "^0.2.1",
 		"karma-firefox-launcher": "^0.1.7",


### PR DESCRIPTION
Just In Time plugin loader for Grunt - https://www.npmjs.com/package/jit-grunt

Improves build time of Grunt tasks by loading plugins as and when they are needed rather than loading them all upfront before executing 
